### PR TITLE
make libgrip gestures optional in autoconf

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -14,8 +14,28 @@ AC_HEADER_STDC
 LDFLAGS="$LDFLAGS -lz -lm"
 
 #pkg_modules="gail >= 1.9.0 libart-2.0 >= 2.3.21 gtk+-3.0 >= 3.0.0 poppler-glib >= 0.5.4 pangoft2 >= 1.0 libgrip" 
-pkg_modules="gtk+-3.0 >= 3.0.0 poppler-glib >= 0.5.4 pangoft2 >= 1.0 libgrip goocanvas-2.0"
+pkg_modules="gtk+-3.0 >= 3.0.0 poppler-glib >= 0.5.4 pangoft2 >= 1.0 goocanvas-2.0"
 # libgrip goocanvas>=3"
+
+
+dnl libgrip gestures: automatically detect but allow override --with/--without
+dnl https://www.flameeyes.eu/autotools-mythbuster/autoconf/arguments.html
+AC_ARG_WITH([libgrip],
+  AS_HELP_STRING([--without-libgrip],
+    [Disable use of libgrip for gestures (pinch-to-zoom, etc) (default: autodetect)])
+)
+
+AS_IF([test "x$with_libgrip" != "xno"],
+  [AC_CHECK_HEADERS([libgrip/grip.h], [have_libgrip=yes], [have_libgrip=no])],
+  [have_libgrip=no])
+
+AS_IF([test "x$have_libgrip" = "xyes"],
+  [AC_DEFINE([HAVE_GRIP_GESTURES], [1], [define if libgrip is present])],
+  [AS_IF([test "x$with_libgrip" = "xyes"],
+    [AC_MSG_ERROR([libgrip/grip.h for gestures requested but not found])
+  ])
+])
+
 
 PKG_CHECK_MODULES(PACKAGE, [$pkg_modules])
 AC_SUBST(PACKAGE_CFLAGS)

--- a/src/main.c
+++ b/src/main.c
@@ -24,8 +24,9 @@
 #include <gdk/gdk.h> 
 #include <gtk/gtk.h>
 #include <goocanvas.h>
-#include<libgrip/grip.h>
-
+#ifdef HAVE_GRIP_GESTURES
+#  include<libgrip/grip.h>
+#endif
 
 #include "xournal.h"
 #include "xo-interface.h"
@@ -48,6 +49,8 @@ struct UndoItem *undo, *redo; // the undo and redo stacks
 
 double DEFAULT_ZOOM;
 
+
+#ifdef HAVE_GRIP_GESTURES
 void
 xo_subscribe_gestures(GtkWidget *window, GtkWidget *scroller) {
 
@@ -69,7 +72,7 @@ xo_subscribe_gestures(GtkWidget *window, GtkWidget *scroller) {
             xo_gesture_callback,
             scroller, NULL);
 }
-
+#endif
 
 
 void xo_describe_device(GdkDevice* device)
@@ -274,7 +277,9 @@ void init_stuff (int argc, char *argv[])
   gtk_adjustment_set_step_increment(adj, ui.scrollbar_step_increment);
 
 
+#ifdef HAVE_GRIP_GESTURES
   xo_subscribe_gestures(GTK_WIDGET(canvas), GTK_WIDGET(canvas));
+#endif
 
 
   // set up the page size and canvas size

--- a/src/xo-callbacks.c
+++ b/src/xo-callbacks.c
@@ -28,8 +28,9 @@
 #include <gdk/gdkkeysyms.h>
 #include <gdk/gdkkeysyms-compat.h>
 
-
-#include <libgrip/grip.h>
+#ifdef HAVE_GRIP_GESTURES
+#  include <libgrip/grip.h>
+#endif
 #include <goocanvas.h>
 #include <assert.h>
 
@@ -3104,6 +3105,7 @@ on_vscroll_changed                     (GtkAdjustment   *adjustment,
     return;
   
   if (ui.progressive_bg)  {
+    TRACE("Going to rescale background\n");
     rescale_bg_pixmaps();
   }
   need_update = FALSE;
@@ -3878,6 +3880,8 @@ on_optionsPenCursor_activate           (GtkCheckMenuItem *checkmenuitem,
   update_cursor();
 }
 
+
+#ifdef HAVE_GRIP_GESTURES
 void
 xo_gesture_callback (GtkWidget        *widget,
                     GripTimeType      time_type,
@@ -3898,3 +3902,4 @@ xo_gesture_callback (GtkWidget        *widget,
     printf("We are pinching, we are pinching\n");
 
 }
+#endif

--- a/src/xo-callbacks.h
+++ b/src/xo-callbacks.h
@@ -15,7 +15,9 @@
 
 
 #include <gtk/gtk.h>
+#ifdef HAVE_GRIP_GESTURES
 #include<libgrip/grip.h>
+#endif
 
 void
 on_fileNew_activate                    (GtkMenuItem     *menuitem,
@@ -666,6 +668,9 @@ void
 on_optionsPenCursor_activate           (GtkCheckMenuItem *checkmenuitem,
                                         gpointer         user_data);
 
-void 
+
+#ifdef HAVE_GRIP_GESTURES
+void
 xo_gesture_callback (GtkWidget        *widget, GripTimeType time_type, GripGestureEvent  *event, gpointer           user_data);
+#endif
 


### PR DESCRIPTION
This makes it compile on Fedora (getting libgrip etc all looks nontrivial).

Should still autodetect on ubuntu but its controllable with "./configure --without-libgrip" or "./configure --with-libgrip"

Hope I've done this right: I'm no autotools expert!
