### PR TITLE
Fix setting window icon

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 #include "xo-file.h"
 #include "xo-paint.h"
 #include "xo-shapes.h"
+#include "xo-image.h"
 
 GtkWidget *winMain;
 GnomeCanvas *canvas;
@@ -551,10 +552,10 @@ main (int argc, char *argv[])
   
   init_stuff (&clOptions);
 
-
-  const GdkPixbuf* pixbuf;
-  create_pixbuf("xournal.png", pixbuf);
-  gtk_window_set_icon(GTK_WINDOW(winMain), pixbuf);
+  gchar *icon = find_pixmap_file("xournal.png");
+  if (icon) {
+      gtk_window_set_default_icon_from_file(icon, NULL);
+  }
   
   if (!clOptions.noNextSplash) {
       xo_warn_user(_("This is not an official build of xournal.\n\n You should not use it unless you understand what you are doing. You have been warned.\n\n--dmg"));

--- a/src/main.c
+++ b/src/main.c
@@ -551,7 +551,10 @@ main (int argc, char *argv[])
   
   init_stuff (&clOptions);
 
-  gtk_window_set_icon(GTK_WINDOW(winMain), create_pixbuf("xournal.png"));
+
+  const GdkPixbuf* pixbuf;
+  create_pixbuf("xournal.png", pixbuf);
+  gtk_window_set_icon(GTK_WINDOW(winMain), pixbuf);
   
   if (!clOptions.noNextSplash) {
       xo_warn_user(_("This is not an official build of xournal.\n\n You should not use it unless you understand what you are doing. You have been warned.\n\n--dmg"));

--- a/src/xo-image.c
+++ b/src/xo-image.c
@@ -175,8 +175,7 @@ add_pixmap_directory                   (const gchar     *directory)
                                         g_strdup (directory));
 }
 
-/* This is an internally used function to find pixmap files. */
-static gchar*
+gchar*
 find_pixmap_file                       (const gchar     *filename)
 {
   GList *elem;
@@ -193,31 +192,4 @@ find_pixmap_file                       (const gchar     *filename)
       elem = elem->next;
     }
   return NULL;
-}
-
-void
-create_pixbuf                          (const gchar     *filename, const GdkPixbuf* pixbuf)
-{
-  gchar *pathname = NULL;
-  GError *error = NULL;
-
-  if (!filename || !filename[0])
-      return NULL;
-
-  pathname = find_pixmap_file (filename);
-
-  if (!pathname)
-    {
-      g_warning (_("Couldn't find pixmap file: %s"), filename);
-      return NULL;
-    }
-
-  pixbuf = gdk_pixbuf_new_from_file (pathname, &error);
-  if (!pixbuf)
-    {
-      fprintf (stderr, "Failed to load pixbuf file: %s: %s\n",
-               pathname, error->message);
-      g_error_free (error);
-    }
-  g_free (pathname);
 }

--- a/src/xo-image.c
+++ b/src/xo-image.c
@@ -195,11 +195,10 @@ find_pixmap_file                       (const gchar     *filename)
   return NULL;
 }
 
-GdkPixbuf*
-create_pixbuf                          (const gchar     *filename)
+void
+create_pixbuf                          (const gchar     *filename, const GdkPixbuf* pixbuf)
 {
   gchar *pathname = NULL;
-  GdkPixbuf *pixbuf;
   GError *error = NULL;
 
   if (!filename || !filename[0])
@@ -221,5 +220,4 @@ create_pixbuf                          (const gchar     *filename)
       g_error_free (error);
     }
   g_free (pathname);
-  return pixbuf;
 }

--- a/src/xo-image.h
+++ b/src/xo-image.h
@@ -17,3 +17,4 @@ GdkPixbuf *pixbuf_from_buffer(const gchar *buf, gsize buflen);
 void create_image_from_pixbuf(GdkPixbuf *pixbuf, double *pt);
 void insert_image(GdkEvent *event);
 void rescale_images(void);
+gchar* find_pixmap_file(const gchar *filename);


### PR DESCRIPTION
The first commit fixes the original issue (where a pointer allocated on the stack was returned to the caller), while the second one switches to using `gtk_window_set_default_icon_from_file` instead.

Fixes #30.